### PR TITLE
Add line for genAI policy

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ before and after the PR.-->
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
-- [ ] Was GenAI used to generate this PR. If it was make sure to add "Generated-By" to your commits
+- [ ] Was GenAI used to generate this PR. If it was make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for mor info.)
 
 Generated-by: Remove this if GenAI was not used.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ before and after the PR.-->
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
-- [ ] Was GenAI used to generate this PR? If it was make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
+- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
 
 Generated-by: Remove this if GenAI was not used.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -23,8 +23,11 @@ before and after the PR.-->
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
+- [ ] Was GenAI used to generate this PR. If it was make sure to add "Generated-By" to your commits
 
-**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
+Generated-by: Remove this if GenAI was not used.
+
+**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
 
 🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
 
@@ -49,8 +52,11 @@ context (e.g., screenshots, gifs) if appropriate.-->
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
+- [ ] Was GenAI used to generate this PR. If it was make sure to add "Generated-By" to your commits
 
-**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
+Generated-by: Remove this if GenAI was not used.
+
+**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
 
 🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -52,7 +52,7 @@ context (e.g., screenshots, gifs) if appropriate.-->
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
-- [ ] Was GenAI used to generate this PR? If it was make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
+- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
 
 Generated-by: Remove this if GenAI was not used.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ before and after the PR.-->
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
-- [ ] Was GenAI used to generate this PR? If it was make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for mor info.)
+- [ ] Was GenAI used to generate this PR? If it was make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
 
 Generated-by: Remove this if GenAI was not used.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -52,7 +52,7 @@ context (e.g., screenshots, gifs) if appropriate.-->
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
-- [ ] Was GenAI used to generate this PR? If it was make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for mor info.)
+- [ ] Was GenAI used to generate this PR? If it was make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
 
 Generated-by: Remove this if GenAI was not used.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ before and after the PR.-->
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
-- [ ] Was GenAI used to generate this PR. If it was make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for mor info.)
+- [ ] Was GenAI used to generate this PR? If it was make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for mor info.)
 
 Generated-by: Remove this if GenAI was not used.
 
@@ -52,7 +52,7 @@ context (e.g., screenshots, gifs) if appropriate.-->
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
-- [ ] Was GenAI used to generate this PR. If it was make sure to add "Generated-By" to your commits
+- [ ] Was GenAI used to generate this PR? If it was make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for mor info.)
 
 Generated-by: Remove this if GenAI was not used.
 


### PR DESCRIPTION
OSRA has a new GenAI policy: https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf

Might be worth putting it into a checklist so that contributors follow the guidelines.