### PR TITLE
Update PR templates to cover screen capture, Bazel, and Backports

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,6 @@ Generated-by: Remove this if GenAI was not used.
 
 **Backports:** If this is a backport, please use **Rebase and Merge** instead.
 
-
 🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
 
 # 🎉 New feature

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -16,18 +16,23 @@ before and after the PR.-->
 
 ## Checklist
 - [ ] Signed all commits for DCO
+- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
 - [ ] Added tests
 - [ ] Updated documentation (as needed)
 - [ ] Updated migration guide (as needed)
 - [ ] Consider updating Python bindings (if the library has them)
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
+- [ ] Updated Bazel files (if adding new new files). Created an issue otherwise.
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
 - [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
 
 Generated-by: Remove this if GenAI was not used.
 
 **Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
+
+**Backports:** If this is a backport, please use **Rebase and Merge** instead.
+
 
 🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
 
@@ -44,6 +49,7 @@ context (e.g., screenshots, gifs) if appropriate.-->
 
 ## Checklist
 - [ ] Signed all commits for DCO
+- [ ] Added a screen capture or video to the PR description that demonstrates the feature
 - [ ] Added tests
 - [ ] Added example and/or tutorial
 - [ ] Updated documentation (as needed)
@@ -51,12 +57,15 @@ context (e.g., screenshots, gifs) if appropriate.-->
 - [ ] Consider updating Python bindings (if the library has them)
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
+- [ ] Updated Bazel files (if adding new new files). Created an issue otherwise.
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
 - [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
 
 Generated-by: Remove this if GenAI was not used.
 
 **Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
+
+**Backports:** If this is a backport, please use **Rebase and Merge** instead.
 
 🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ before and after the PR.-->
 - [ ] Consider updating Python bindings (if the library has them)
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
-- [ ] Updated Bazel files (if adding new new files). Created an issue otherwise.
+- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
 - [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
 
@@ -57,7 +57,7 @@ context (e.g., screenshots, gifs) if appropriate.-->
 - [ ] Consider updating Python bindings (if the library has them)
 - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
 - [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
-- [ ] Updated Bazel files (if adding new new files). Created an issue otherwise.
+- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
 - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
 - [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
 


### PR DESCRIPTION
Per discussions in the Gazebo PMC, this updates the PR template to encourage adding a screen capture/video and to update Bazel files. This also adds backporting instructions to feature and bug fix PRs 